### PR TITLE
Do not assume an anonymous client is public.

### DIFF
--- a/oa4mp-server-loader-oauth2/src/main/java/edu/uiuc/ncsa/myproxy/oa4mp/oauth2/cm/oidc_cm/OIDCCMServlet.java
+++ b/oa4mp-server-loader-oauth2/src/main/java/edu/uiuc/ncsa/myproxy/oa4mp/oauth2/cm/oidc_cm/OIDCCMServlet.java
@@ -754,7 +754,7 @@ public class OIDCCMServlet extends EnvServlet {
         debugger.trace(this, "Setting approval record for this client");
         ClientApproval approval = new ClientApproval(newClient.getIdentifier());
         approval.setApprovalTimestamp(new Date());
-        if (isAnonymous && newClient.isPublicClient()) {
+        if (isAnonymous) {
             if (cm7591Config.autoApprove) {
                 approval.setApprover(cm7591Config.autoApproverName);
                 approval.setApproved(true);


### PR DESCRIPTION
Anonymous clients may be able to manage their credentials just fine; anonymous does not imply public!

Fixes a null pointer exception that occurs on the `adminClient` variable when the the dynamic client registration is anonymous and non-public.