### PR TITLE
Bring up javadoc up to Java 11 standards

### DIFF
--- a/client/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/client/DelegationService.java
+++ b/client/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/client/DelegationService.java
@@ -90,9 +90,9 @@ public abstract class DelegationService implements Server {
      * Gets the asset once the delegation has been approved. This will typically involve getting tokens as
      * needed from the authorization server then accessing the resource server, so this actually does two
      * legs in the protocol in quick succession. If you need to do these separately, then invoke
-     * them as <br/><br/>
-     * getAT<br/>
-     * getCert<br/><br/>
+     * them as <br><br>
+     * getAT<br>
+     * getCert<br><br>
      * with the correct parameters.
      *
      * @return

--- a/client/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/client/request/BasicRequest.java
+++ b/client/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/client/request/BasicRequest.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * Clients will need to send along parameters in their requests. This is done with a standard {@link Map}.
  * The Map will have every key value pair appended to the request. No formatting or other processing
  * will be done to these so be sure to do this first.
- * <p/>
+ * <p><br>
  * <p>Created by Jeff Gaynor<br>
  * on Apr 26, 2011 at  1:58:56 PM
  */

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/OA2ConfigurationLoaderUtils.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/OA2ConfigurationLoaderUtils.java
@@ -26,16 +26,16 @@ public class OA2ConfigurationLoaderUtils extends ConfigUtil {
      * &lt;/parameters&gt;
      * </pre>
      * where the keys and values will be properly encoded (so you don't have to do it). These
-     * will end up in the request as <code&gt;...&key0=value0&key1=value1&...</code>. Note that
+     * will end up in the request as <code>...&amp;key0=value0&amp;key1=value1&amp;...</code>. Note that
      * the value sent is the body of the element, so you can literally send anything if you include it
      * in a CDATA tag.
-     * </p>
+     *
      * <p>
      * There is an <i>optional</i> flag to enable these. No flag means it is enabled. Disabling will
      * prevent it from being included. This allows you to turn on and off parameters in the file
      * without having to comment things out or remove them. Note that at this point, these are only
      * sent in the initial request.
-     * </p>
+     *
      *
      * @param cn
      * @return

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/UserInfo.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/UserInfo.java
@@ -13,7 +13,7 @@ import static edu.uiuc.ncsa.oa4mp.delegation.oa2.server.claims.OA2Claims.*;
  * The only required field is "sub" -- all others are optional.  The
  * getJSON() method should return a JSON response string based on the
  * class variables.  Can be subclassed to support getting user info
- * from different sources> This uses a map internally
+ * from different sources. This uses a map internally
  * since otherwise it is much trickier to
  * turn this into a valid JSON object.
  */

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/client/ATServer2.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/client/ATServer2.java
@@ -34,7 +34,7 @@ public class ATServer2 extends TokenAwareServer implements ATServer {
      * get them back, they are checked for validity and passed along to the client. The problem is that
      * many applications (such as Kubernetes) are using them as a "poor man's SciToken", necessitating
      * that we keep them around for at least a bit. This store holds the raw token (as a string) and
-     * the corresponding {@link net.sf.json.JSONObject} keyed by {@link edu.uiuc.ncsa.security.delegation.token.AccessToken}.
+     * the corresponding {@link net.sf.json.JSONObject} keyed by {@link edu.uiuc.ncsa.oa4mp.delegation.common.token.AccessToken}.
      */
 
     public static class IDTokenEntry {

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/client/DS2.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/client/DS2.java
@@ -66,7 +66,7 @@ public class DS2 extends DelegationService {
 
     /**
      * As per spec., issue request for refresh from server. Returned {@link RTResponse} has the associated
-     * {@link edu.uiuc.ncsa.security.delegation.token.RefreshToken} and {@link AccessToken}.
+     * {@link edu.uiuc.ncsa.oa4mp.delegation.common.token.RefreshToken} and {@link AccessToken}.
      *
      * @return
      */

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/AccessTokenHandlerInterface.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/AccessTokenHandlerInterface.java
@@ -10,7 +10,7 @@ import edu.uiuc.ncsa.security.util.jwk.JSONWebKey;
 public interface AccessTokenHandlerInterface extends PayloadHandler {
     /**
      * The actual simple access token (usually used as the identifier for the claims-based AT.
-     * To get the signed claims, invoke {@link #getSignedAT(JSONWebKey}.
+     * To get the signed claims, invoke {@link #getSignedAT(JSONWebKey)}.
      * @return
      */
     AccessToken getAccessToken();

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/JWTRunner.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/JWTRunner.java
@@ -312,7 +312,7 @@ public class JWTRunner {
      * called after all claims sources have been processed  and the script just massages the claims or flow states.
      *
      * @param scriptRunResponse
-     * @return
+     *
      */
 
     protected void handleSREResponse(OIDCServiceTransactionInterface transaction, ScriptRunResponse scriptRunResponse) throws IOException {

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/JWTUtil2.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/JWTUtil2.java
@@ -35,8 +35,8 @@ import static edu.uiuc.ncsa.security.core.util.StringUtils.isTrivial;
  * Creates JWT tokens. This will create both signed and unsigned tokens
  * if requested. The format is to have a header that describes the
  * content, including algorithm (fixed at "none" here) and a payload of claims. Both of these
- * are in JSON. The token then consists of based64 encoding both of these and <br/><br>
- * encoded header + "."   + encoded payload + "." + signature<br/><br>
+ * are in JSON. The token then consists of based64 encoding both of these and <br><br>
+ * encoded header + "."   + encoded payload + "." + signature<br><br>
  * If the token is unsigned, the last period is still manadatory and must end this.
  *
  * <p>Created by Jeff Gaynor<br>

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/PayloadHandler.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/jwt/PayloadHandler.java
@@ -34,7 +34,7 @@ public interface PayloadHandler extends Serializable {
      * Marshall any resources this script needs to make a request.
      * I.e., add specific state (if needed) from this handler
      * to the {@link ScriptRunRequest}.
-     * @return
+     *
      */
     void addRequestState(ScriptRunRequest req)  throws Throwable;
 
@@ -95,7 +95,7 @@ public interface PayloadHandler extends Serializable {
     /**
      * This is used on refresh only. It will reset all the standard accounting information
      * (such as timestamps) for an existing claims object.
-     * <h4>Usage</h4>
+     * <h3>Usage</h3>
      * Create an instance of the handler with the constructor for any state, then invoke this method.
      */
     void refreshAccountingInformation();

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/ATI2.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/ATI2.java
@@ -24,7 +24,7 @@ public class ATI2 extends AbstractIssuer implements ATIssuer {
     /**
     Constructor
     @param tokenForge Token forge to use
-    @address URI of access token endpoint
+    @param address URI of access token endpoint
      */
     public ATI2(TokenForge tokenForge, URI address,boolean isOIDC) {
         super(tokenForge, address);

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/PAI2.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/PAI2.java
@@ -28,7 +28,7 @@ public class PAI2 extends AbstractIssuer implements PAIssuer {
     /**
     Process cert request
     @param paRequest Protected asset request object
-    @response Protected asset response object
+    @return Protected asset response object
     */
     public PAResponse processProtectedAsset(PARequest paRequest) {
         try {

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/RFC7662Constants.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/RFC7662Constants.java
@@ -4,7 +4,7 @@ package edu.uiuc.ncsa.oa4mp.delegation.oa2.server;
  * Constants for <a href="https://datatracker.ietf.org/doc/html/rfc7662">RFC 7662</a>,
  * the token introspection endpoint.
  * <h2>Note</h2>
- * These are also used in <a href="https://datatracker.ietf.org/doc/html/rfc7009"></a>RFC 7009</a>,
+ * These are also used in <a href="https://datatracker.ietf.org/doc/html/rfc7009">RFC 7009</a>,
  * for token revocation.
  * <p>Created by Jeff Gaynor<br>
  * on 5/19/21 at  7:18 AM

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/claims/ClaimSourceConfigurationUtil.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/claims/ClaimSourceConfigurationUtil.java
@@ -57,7 +57,7 @@ public class ClaimSourceConfigurationUtil {
      * is the claim source, e.g. ldap that is used. The default is "default". The vlaue is the actual configuration.
      * This lets you stick these all over
      * the place and they stay encapsulated nicely in JSON configuration files.
-     * <p/>
+     * <p>
      * The value will be of the form {"enabled":"true",...} (so all the tags are top-level in it).
      *
      * @param logger

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/config/LDAPConfiguration.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/config/LDAPConfiguration.java
@@ -228,11 +228,11 @@ public class LDAPConfiguration extends JSONClaimSourceConfig {
     /**
      * This is used as part of the search filter. A normal one would be
      * <pre>
-     *     ((& + {@link #getSearchFilterAttribute} + claim + )({@link #getAdditionalFilter}))
+     *     ((&amp; + {@link #getSearchFilterAttribute} + claim + )({@link #getAdditionalFilter}))
      * </pre>
      * So one might look like
      * <pre>
-     *     (&(uid=bob)(isMemberOf=Communities:LVC:SegDB:SegDBWriter))
+     *     (&amp;(uid=bob)(isMemberOf=Communities:LVC:SegDB:SegDBWriter))
      * </pre>
      * Generally this will be dropped verbatim in the slot, so include parentheses.
      * @return

--- a/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/scripts/ClientJSONConfigUtil.java
+++ b/oauth2/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/oa2/server/scripts/ClientJSONConfigUtil.java
@@ -11,7 +11,7 @@ import net.sf.json.JSONObject;
  * to modularize operations on the JSON. Note that the "thingy" refers to a JSON idiom, often used here <i>viz.</i>,
  * a configuration entry of the form {"topLevelKey":JSON} where JSON is either an array or json object.
  * These may be done at any level of the configuration file, so be sure to send in the right JSON object with the topLevelKey.
- * <p/>
+ * <p><br>
  * <p>Created by Jeff Gaynor<br>
  * on 8/30/17 at  3:37 PM
  */
@@ -60,7 +60,7 @@ public class ClientJSONConfigUtil {
 
     /**
      * Return the {@link JSONObject} for the given key. This will fail if there is not a single object there,
-     * <p/>
+     * <p>
      * <pre>
      *  Z=   {"key0":{
      *         "key1':X

--- a/server/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/server/request/CBRequest.java
+++ b/server/src/main/java/edu/uiuc/ncsa/oa4mp/delegation/server/request/CBRequest.java
@@ -11,7 +11,7 @@ import java.net.URI;
 
 /**
  * Request to a callback server.
- * <br/>OAuth 1 specific.
+ * <br>OAuth 1 specific.
  * <p>Created by Jeff Gaynor<br>
  * on May 23, 2011 at  11:30:10 AM
  */


### PR DESCRIPTION
Previously, javadocs failed to build across the projects as many had constructs that trigger an error in Java 8 or later.  This at least allows maven to build with Java 11.