### PR TITLE
Check null before casting to string

### DIFF
--- a/proxy/src/main/java/org/oa4mp/server/proxy/OA2AuthorizationServer.java
+++ b/proxy/src/main/java/org/oa4mp/server/proxy/OA2AuthorizationServer.java
@@ -106,8 +106,8 @@ public class OA2AuthorizationServer extends AbstractAuthorizationServlet {
         // issue now is that the nonce was registered in the init servlet (as it should be for OA1)
         // and now it will be rejected ever more.
         JSONObject j = JSONObject.fromObject(content);
-        String code = j.get("code").toString();
-        String state = j.get("state").toString();
+        String code = j.containsKey("code") ? j.get("code").toString() : null;
+        String state = j.containsKey("state") ? j.get("state").toString() : null;
         // Fix RCAuth https://github.com/rcauth-eu/OA4MP/commit/d052e0a64fe527adb7636fe146179ffbac472380
         if (code != null) {
             request.setAttribute("code", code);


### PR DESCRIPTION
This prevents a null pointer error when trying to cast an unset `state` parameter to a string when completing the Authorization Code Flow.

Per RFC 6749 `state` is only strongly recommended. I ran into this null pointer during some dev work in which security wasn't important yet.